### PR TITLE
Fixing snake_case to cammelCase in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ package {subdomain}
 import "github.com/ozonmp/omp-bot/internal/model/{domain}"
 
 type {Subdomain}Service interface {
-  Describe({subdomain}_id uint64) (*{domain}.{Subdomain}, error)
+  Describe({subdomain}ID uint64) (*{domain}.{Subdomain}, error)
   List(cursor uint64, limit uint64) ([]{domain}.{Subdomain}, error)
   Create({domain}.{Subdomain}) (uint64, error)
-  Update({subdomain}_id uint64, {subdomain} {domain}.{Subdomain}) error
-  Remove({subdomain}_id uint64) (bool, error)
+  Update({subdomain}ID uint64, {subdomain} {domain}.{Subdomain}) error
+  Remove({subdomain}ID uint64) (bool, error)
 }
 
 type Dummy{Subdomain}Service struct {}


### PR DESCRIPTION
Пока не получил домен, поэтому действую по с шаблонными названиями.
Заметил маленькое нарушение код-стайла. Хотя в этом случае чтение через snake_case более очевидно.